### PR TITLE
Add missing includes for musl libc

### DIFF
--- a/IODash/Serial.hpp
+++ b/IODash/Serial.hpp
@@ -16,6 +16,7 @@
 #include <system_error>
 #include <unordered_map>
 
+#include <asm/ioctls.h>
 #include <sys/ioctl.h>
 
 #ifdef __linux__

--- a/IODash/SocketAddress.hpp
+++ b/IODash/SocketAddress.hpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include <cinttypes>
+#include <cstring>
 
 #include <sys/types.h>
 #include <sys/socket.h>


### PR DESCRIPTION
`IODash` currently fails to build on musl; I found it while packaging `ydotool` for Void Linux...

see https://github.com/void-linux/void-packages/pull/31237